### PR TITLE
Add routes and associated unit tests for Environments

### DIFF
--- a/app/tests/system.server.routes.test.js
+++ b/app/tests/system.server.routes.test.js
@@ -278,8 +278,8 @@ describe('System CRUD tests', function() {
             return agent.post('/auth/signin').send(credentials).expect(200).endAsync();
         })
         .then(function(signinRes){
-            return agent.get('/systems/' + systemObj._id
-                           + '/environments/' + systemObj.environments[0].name)
+            return agent.get('/systems/' + systemObj._id +
+                             '/environments/' + systemObj.environments[0].name)
             .expect(200).endAsync();
         })
         .then(function(res) {
@@ -287,7 +287,7 @@ describe('System CRUD tests', function() {
             done();
         })
         .catch(console.error);
-    })
+    });
 
     afterEach(function(done) {
         User.remove().exec();


### PR DESCRIPTION
*(Please merge requests #5 and #6 to see an accurate diff)*

This pull request creates a new route and tests it:
`'/systems/:systemId/environments/:environmentName'`

Response is the environment data as returned from the database (which, right now, isn't much):

The request `/systems/5571f07f3209a8ad579775c0/environments/b` yields:
```
{"repos":[],"name":"b"}
```